### PR TITLE
Add quoting to filename part of Content-Disposition header.

### DIFF
--- a/lib/excel_rails.rb
+++ b/lib/excel_rails.rb
@@ -18,7 +18,7 @@ module Spreadsheet
       def disposition(download, filename)
         download = true if (filename && download == nil)
         disposition = download ? "attachment;" : "inline;"
-        disposition += " filename=#{filename}" if filename
+        disposition += " filename=\"#{filename}\"" if filename
         headers["Content-Disposition"] = disposition
       end
     end


### PR DESCRIPTION
This fixes truncated file names in Firefox when spaces are part of the filename.
